### PR TITLE
feat: add App Open Ads support, fixes banner bug on iOS, adds app ID support on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,11 @@ A Cordova AdMob plugin used for Android and iOS.  It is free, with no ad sharing
 To install this plugin, follow the [Command-line Interface Guide](http://cordova.apache.org/docs/en/edge/guide_cli_index.md.html#The%20Command-line%20Interface). You can use one of the following command lines:
 
 ```
-cordova plugin add cordova-admob-jimmy --variable ADMOB_APP_ID="<YOUR_ANDROID_ADMOB_APP_ID_AS_FOUND_IN_ADMOB>"
+cordova plugin add cordova-admob-jimmy --variable ADMOB_APP_ID="<YOUR_ANDROID_ADMOB_APP_ID_AS_FOUND_IN_ADMOB>" --variable IOS_APP_ID="<YOUR_IOS_ADMOB_APP_ID>"
 
 ```
 * Note: If you add the correct ADMOB_APP_ID after the build you may need to remove the plugin and re-add it as the original value is saved in the plugin folder and overrides the config settings.
 
-
-
-Since version 7.42 of the Google AdMob Mobile Ads SDK for iOS, you must add the ADMOB_APP_ID to your Info.plist, which you can do by adding the folowing inside the <platform name="ios"> section in your config.xml file:
-
-```
-<config-file target="*-Info.plist" parent="GADApplicationIdentifier">
-    <string>YOUR_IOS_ADMOB_APP_ID_AS_FOUND_IN_ADMOB</string>
-</config-file>
-```
 
 ## Change Log ##
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,83 +1,84 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-admob-jimmy" version="4.6.2">
-  <description>Google AdMob Ads plugin for Cordova, Phonegap, Ionic/Angular and Intel XDK. Monetize your app with one javascript line. Android SDK v7.5, iOS SDK v7.3.1. With support for tappx and auto-detect internet connection.</description>
-  <name>AdMob Google Ads - Clean</name>
-  <author href="https://github.com/jamesfdickinson/admob-google-cordova-clean">jamesfdickinson</author>
-  <license>MIT</license>
-  <keywords>ad,ads,admob,google,advertising,advertisment,publicity,earn,win,play,services,iad,flurry,monetization,money,appfeel,tappx</keywords>
-  <repo>https://github.com/jamesfdickinson/admob-google-cordova-clean.git</repo>
-  <issue>https://github.com/jamesfdickinson/admob-google-cordova-clean/issues</issue>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+	xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-admob-jimmy" version="4.6.2">
+	<description>Google AdMob Ads plugin for Cordova, Phonegap, Ionic/Angular and Intel XDK. Monetize your app with one javascript line. Android SDK v7.5, iOS SDK v7.3.1. With support for tappx and auto-detect internet connection.</description>
+	<name>AdMob Google Ads - Clean</name>
+	<author href="https://github.com/jamesfdickinson/admob-google-cordova-clean">jamesfdickinson</author>
+	<license>MIT</license>
+	<keywords>ad,ads,admob,google,advertising,advertisment,publicity,earn,win,play,services,iad,flurry,monetization,money,appfeel,tappx</keywords>
+	<repo>https://github.com/jamesfdickinson/admob-google-cordova-clean.git</repo>
+	<issue>https://github.com/jamesfdickinson/admob-google-cordova-clean/issues</issue>
 
-  <engines>
-    <engine name="cordova" version=">=8.0.0" />
-  </engines>
+	<engines>
+		<engine name="cordova" version=">=8.0.0" />
+	</engines>
 
 
-  <js-module src="www/admob.js" name="AdMobAds">
-    <clobbers target="window.admob" />
-  </js-module>
+	<js-module src="www/admob.js" name="AdMobAds">
+		<clobbers target="window.admob" />
+	</js-module>
 
-  <!-- <hook type="after_plugin_add" src="scripts/100-prepare-admob-angular.js" />
+	<!-- <hook type="after_plugin_add" src="scripts/100-prepare-admob-angular.js" />
   <asset src="www/angular-admob.js" target="lib/angular-admob/angular-admob.js" /> -->
 
-  <!-- android -->
-  <platform name="android">
-    <config-file target="res/xml/config.xml" parent="/*">
-      <feature name="AdMobAds">
-        <param name="android-package" value="com.appfeel.cordova.admob.AdMobAds" />
-      </feature>
-    </config-file>
+	<!-- android -->
+	<platform name="android">
+		<config-file target="res/xml/config.xml" parent="/*">
+			<feature name="AdMobAds">
+				<param name="android-package" value="com.appfeel.cordova.admob.AdMobAds" />
+			</feature>
+		</config-file>
 
-    <config-file target="AndroidManifest.xml" parent="/manifest/application">
-      <activity android:name="com.google.android.gms.ads.AdActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize" android:theme="@android:style/Theme.Translucent" />
-      <meta-data  android:name="com.google.android.gms.ads.APPLICATION_ID"  android:value="$ADMOB_APP_ID"/>
-    </config-file>
+		<config-file target="AndroidManifest.xml" parent="/manifest/application">
+			<activity android:name="com.google.android.gms.ads.AdActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize" android:theme="@android:style/Theme.Translucent" />
+			<meta-data android:name="com.google.android.gms.ads.APPLICATION_ID" android:value="$ADMOB_APP_ID"/>
+		</config-file>
 
-    <config-file target="AndroidManifest.xml" parent="/*">
-      <uses-permission android:name="android.permission.INTERNET" />
-      <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    </config-file>
+		<config-file target="AndroidManifest.xml" parent="/*">
+			<uses-permission android:name="android.permission.INTERNET" />
+			<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+		</config-file>
 
-    <framework src="com.google.android.gms:play-services-ads:+" />
-    <!-- <framework src="com.google.android.gms:play-services-measurement:+" />
+		<framework src="com.google.android.gms:play-services-ads:+" />
+		<!-- <framework src="com.google.android.gms:play-services-measurement:+" />
     <framework src="com.google.android.gms:play-services-measurement-sdk:+" />  -->
-    <!--<framework src="com.google.firebase:firebase-ads:+" />-->
+		<!--<framework src="com.google.firebase:firebase-ads:+" />-->
 
 
 
-    <source-file src="src/android/AdMobAds.java" target-dir="src/com/appfeel/cordova/admob" />
-    <source-file src="src/android/AdMobAdsAdListener.java" target-dir="src/com/appfeel/cordova/admob" />
-    <source-file src="src/android/AdMobRewardedVideoAdListener.java" target-dir="src/com/appfeel/cordova/admob" />
+		<source-file src="src/android/AdMobAds.java" target-dir="src/com/appfeel/cordova/admob" />
+		<source-file src="src/android/AdMobAdsAdListener.java" target-dir="src/com/appfeel/cordova/admob" />
+		<source-file src="src/android/AdMobRewardedVideoAdListener.java" target-dir="src/com/appfeel/cordova/admob" />
 
-    <preference name="ADMOB_APP_ID" />
-  </platform>
+		<preference name="ADMOB_APP_ID" />
+	</platform>
 
-  <!-- ios -->
-  <platform name="ios">
-    <config-file target="config.xml" parent="/*">
-      <feature name="AdMobAds">
-        <param name="ios-package" value="CDVAdMobAds" />
-      </feature>
-    </config-file>
+	<!-- ios -->
+	<platform name="ios">
+		<config-file target="config.xml" parent="/*">
+			<feature name="AdMobAds">
+				<param name="ios-package" value="CDVAdMobAds" />
+			</feature>
+		</config-file>
 
-    <header-file src="src/ios/CDVAdMobAds.h" />
-    <source-file src="src/ios/CDVAdMobAds.m" />
-    <header-file src="src/ios/CDVAdMobAdsAdListener.h" />
-    <source-file src="src/ios/CDVAdMobAdsAdListener.m" />
+		<header-file src="src/ios/CDVAdMobAds.h" />
+		<source-file src="src/ios/CDVAdMobAds.m" />
+		<header-file src="src/ios/CDVAdMobAdsAdListener.h" />
+		<source-file src="src/ios/CDVAdMobAdsAdListener.m" />
 
-    <!-- Google AdMob framework -->
-    <!-- <framework src="Google-Mobile-Ads-SDK" type="podspec"  /> -->
-    <!-- <framework src="Firebase/Analytics" type="podspec" />
+		<!-- Google AdMob framework -->
+		<!-- <framework src="Google-Mobile-Ads-SDK" type="podspec" /> -->
+		<!-- <framework src="Firebase/Analytics" type="podspec" />
     <framework src="Firebase/AdMob" type="podspec" /> -->
-    <podspec>
-            <config>
-                <source url="https://github.com/CocoaPods/Specs.git"/>
-            </config>
-            <pods>
-                 <pod name="Google-Mobile-Ads-SDK"  />
-                <!-- <pod name="Firebase/Analytics"  />
-                <pod name="Firebase/AdMob"  /> -->
-            </pods>
-        </podspec>
-  </platform>
+		<podspec>
+			<config>
+				<source url="https://github.com/CocoaPods/Specs.git"/>
+			</config>
+			<pods>
+				<pod name="Google-Mobile-Ads-SDK" />
+				<!-- <pod name="Firebase/Analytics" />
+                <pod name="Firebase/AdMob" /> -->
+			</pods>
+		</podspec>
+	</platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -55,6 +55,11 @@
 
 	<!-- ios -->
 	<platform name="ios">
+		<preference name="IOS_APP_ID" />
+
+		<config-file target="*-Info.plist" parent="GADApplicationIdentifier">
+			<string>$IOS_APP_ID</string>
+		</config-file>
 		<config-file target="config.xml" parent="/*">
 			<feature name="AdMobAds">
 				<param name="ios-package" value="CDVAdMobAds" />

--- a/src/android/AdMobAds.java
+++ b/src/android/AdMobAds.java
@@ -54,782 +54,883 @@ import android.view.Window;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
+import com.google.android.gms.ads.AdError;
+import com.google.android.gms.ads.FullScreenContentCallback;
+import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.InterstitialAd;
+import com.google.android.gms.ads.appopen.AppOpenAd;
 import com.google.android.gms.ads.mediation.admob.AdMobExtras;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.reward.RewardedVideoAd;
 
 public class AdMobAds extends CordovaPlugin {
-    public static final String ADMOBADS_LOGTAG = "AdmMobAds";
-    public static final String INTERSTITIAL = "interstitial";
-    public static final String BANNER = "banner";
-    public static final String REWARDED = "rewarded";
+	public static final String ADMOBADS_LOGTAG = "AdmMobAds";
+	public static final String INTERSTITIAL = "interstitial";
+	public static final String BANNER = "banner";
+	public static final String REWARDED = "rewarded";
+	public static final String APP_OPEN = "app_open";
 
-    private static final boolean CORDOVA_4 = Integer.valueOf(CordovaWebView.CORDOVA_VERSION.split("\\.")[0]) >= 4;
+	private static final boolean CORDOVA_4 = Integer.valueOf(CordovaWebView.CORDOVA_VERSION.split("\\.")[0]) >= 4;
 
-    /* Cordova Actions. */
-    private static final String ACTION_SET_OPTIONS = "setOptions";
-    private static final String ACTION_CREATE_BANNER_VIEW = "createBannerView";
-    private static final String ACTION_SHOW_BANNER_AD = "showBannerAd";
-    private static final String ACTION_DESTROY_BANNER_VIEW = "destroyBannerView";
-    private static final String ACTION_REQUEST_INTERSTITIAL_AD = "requestInterstitialAd";
-    private static final String ACTION_SHOW_INTERSTITIAL_AD = "showInterstitialAd";
-    private static final String ACTION_REQUEST_REWARDED_AD = "requestRewardedAd";
-    private static final String ACTION_SHOW_REWARDED_AD = "showRewardedAd";
-    private static final String ACTION_RECORD_RESOLUTION = "recordResolution";
-    private static final String ACTION_RECORD_PLAY_BILLING_RESOLUTION = "recordPlayBillingResolution";
+	/* Cordova Actions. */
+	private static final String ACTION_SET_OPTIONS = "setOptions";
+	private static final String ACTION_CREATE_BANNER_VIEW = "createBannerView";
+	private static final String ACTION_SHOW_BANNER_AD = "showBannerAd";
+	private static final String ACTION_DESTROY_BANNER_VIEW = "destroyBannerView";
+	private static final String ACTION_REQUEST_INTERSTITIAL_AD = "requestInterstitialAd";
+	private static final String ACTION_SHOW_INTERSTITIAL_AD = "showInterstitialAd";
+	private static final String ACTION_REQUEST_REWARDED_AD = "requestRewardedAd";
+	private static final String ACTION_SHOW_REWARDED_AD = "showRewardedAd";
+	private static final String ACTION_REQUEST_APP_OPEN_AD = "requestAppOpenAd";
+	private static final String ACTION_SHOW_APP_OPEN_AD = "showAppOpenAd";
+	private static final String ACTION_RECORD_RESOLUTION = "recordResolution";
+	private static final String ACTION_RECORD_PLAY_BILLING_RESOLUTION = "recordPlayBillingResolution";
 
-    /* options */
-    private static final String OPT_APP_ID = "appId";
-    private static final String OPT_PUBLISHER_ID = "bannerAdId";
-    private static final String OPT_INTERSTITIAL_AD_ID = "interstitialAdId";
-    private static final String OPT_REWARDED_AD_ID = "rewardedAdId";
-    private static final String OPT_AD_SIZE = "adSize";
-    private static final String OPT_BANNER_AT_TOP = "bannerAtTop";
-    private static final String OPT_OVERLAP = "overlap";
-    private static final String OPT_OFFSET_STATUSBAR = "offsetStatusBar";
-    private static final String OPT_IS_TESTING = "isTesting";
-    private static final String OPT_AD_EXTRAS = "adExtras";
-    private static final String OPT_AUTO_SHOW_BANNER = "autoShowBanner";
-    private static final String OPT_AUTO_SHOW_INTERSTITIAL = "autoShowInterstitial";
-    private static final String OPT_AUTO_SHOW_REWARDED = "autoShowRewarded";
-    private static final String OPT_TAPPX_ID_ANDROID = "tappxIdAndroid";
-    private static final String OPT_TAPPX_SHARE = "tappxShare";
-    protected boolean isBannerAutoShow = true;
-    protected boolean isInterstitialAutoShow = true;
-    protected boolean isRewardedAutoShow = false;
-    private AdMobAdsAdListener bannerListener = new AdMobAdsAdListener(BANNER, this);
-    private AdMobAdsAdListener interstitialListener = new AdMobAdsAdListener(INTERSTITIAL, this);
-    private AdMobRewardedVideoAdListener rewardedListener = new AdMobRewardedVideoAdListener(REWARDED, this);
-    private boolean isMobileAdsInitialized = false;
-    private boolean isInterstitialAvailable = false;
-    private boolean isRewardedAvailable = false;
-    private boolean isNetworkActive = false;
-    //private View adView;
-    //private SearchAdView sadView;
-    private ViewGroup parentView;
-    /**
-     * The adView to display to the user.
-     */
-    private AdView adView;
-    /**
-     * if want banner view overlap webview, we will need this layout
-     */
-    private RelativeLayout adViewLayout = null;
-    /**
-     * The interstitial ad to display to the user.
-     */
-    private InterstitialAd interstitialAd;
-    private RewardedVideoAd  rewardedAd;
-    private String appId = ""; // App ID from AdMob
-    private String publisherId = "";
-    private String interstitialAdId = "";
-    private String rewardedAdId = "";
-    private String tappxId = "";
-    private AdSize adSize = AdSize.SMART_BANNER;
+	/* options */
+	private static final String OPT_APP_ID = "appId";
+	private static final String OPT_PUBLISHER_ID = "bannerAdId";
+	private static final String OPT_INTERSTITIAL_AD_ID = "interstitialAdId";
+	private static final String OPT_REWARDED_AD_ID = "rewardedAdId";
+	private static final String OPT_APP_OPEN_AD_ID = "appOpenAdId";
+	private static final String OPT_AD_SIZE = "adSize";
+	private static final String OPT_BANNER_AT_TOP = "bannerAtTop";
+	private static final String OPT_OVERLAP = "overlap";
+	private static final String OPT_OFFSET_STATUSBAR = "offsetStatusBar";
+	private static final String OPT_IS_TESTING = "isTesting";
+	private static final String OPT_AD_EXTRAS = "adExtras";
+	private static final String OPT_AUTO_SHOW_BANNER = "autoShowBanner";
+	private static final String OPT_AUTO_SHOW_INTERSTITIAL = "autoShowInterstitial";
+	private static final String OPT_AUTO_SHOW_REWARDED = "autoShowRewarded";
+	private static final String OPT_TAPPX_ID_ANDROID = "tappxIdAndroid";
+	private static final String OPT_TAPPX_SHARE = "tappxShare";
+	protected boolean isBannerAutoShow = true;
+	protected boolean isInterstitialAutoShow = true;
+	protected boolean isRewardedAutoShow = false;
+	private AdMobAdsAdListener bannerListener = new AdMobAdsAdListener(BANNER, this);
+	private AdMobAdsAdListener interstitialListener = new AdMobAdsAdListener(INTERSTITIAL, this);
+	private AdMobAdsAdListener appOpenListener = new AdMobAdsAdListener(APP_OPEN, this);
+	private AdMobRewardedVideoAdListener rewardedListener = new AdMobRewardedVideoAdListener(REWARDED, this);
+	private boolean isMobileAdsInitialized = false;
+	private boolean isInterstitialAvailable = false;
+	private boolean isRewardedAvailable = false;
+	private boolean isNetworkActive = false;
+	//private View adView;
+	//private SearchAdView sadView;
+	private ViewGroup parentView;
+	/**
+	 * The adView to display to the user.
+	 */
+	private AdView adView;
+	/**
+	 * if want banner view overlap webview, we will need this layout
+	 */
+	private RelativeLayout adViewLayout = null;
+	/**
+	 * The interstitial ad to display to the user.
+	 */
+	private InterstitialAd interstitialAd;
+	private RewardedVideoAd rewardedAd;
+	private String appId = ""; // App ID from AdMob
+	private String publisherId = "";
+	private String interstitialAdId = "";
+	private String rewardedAdId = "";
+	private String tappxId = "";
+	private AdSize adSize = AdSize.SMART_BANNER;
+
+	/**
+	 * App Open ad
+	 */
+	private AppOpenAd appOpenAd = null;
+	private String appOpenId = "";
+	private static boolean isShowingAppOpenAd = false;
+	private AppOpenAd.AppOpenAdLoadCallback loadCallback;
+
+	/**
+	 * Whether or not the ad should be positioned at top or bottom of screen.
+	 */
+	private boolean isBannerAtTop = false;
+	/**
+	 * Whether or not the banner will overlap the webview instead of push it up or down
+	 */
+	private boolean isBannerOverlap = false;
+	private boolean isOffsetStatusBar = false;
+	private boolean isTesting = false;
+	private JSONObject adExtras = null;
+	private boolean isBannerVisible = false;
+	private double tappxShare = 0.5;
+	private boolean hasTappx = false;
+
+	/**
+	 * Gets an AdSize object from the string size passed in from JavaScript. Returns null if an improper string is provided.
+	 *
+	 * @param size The string size representing an ad format constant.
+	 * @return An AdSize object used to create a banner.
+	 */
+	public static AdSize adSizeFromString(String size) {
+		if ("BANNER".equals(size)) {
+			return AdSize.BANNER;
+		} else if ("IAB_MRECT".equals(size)) {
+			return AdSize.MEDIUM_RECTANGLE;
+		} else if ("IAB_BANNER".equals(size)) {
+			return AdSize.FULL_BANNER;
+		} else if ("IAB_LEADERBOARD".equals(size)) {
+			return AdSize.LEADERBOARD;
+		} else if ("SMART_BANNER".equals(size)) {
+			return AdSize.SMART_BANNER;
+		} else {
+			return AdSize.SMART_BANNER;
+		}
+	}
+
+	public static final String md5(final String s) {
+		try {
+			MessageDigest digest = java.security.MessageDigest.getInstance("MD5");
+			digest.update(s.getBytes());
+			byte messageDigest[] = digest.digest();
+			StringBuilder hexString = new StringBuilder();
+			for (byte i : messageDigest) {
+				String h = Integer.toHexString(0xFF & i);
+				while (h.length() < 2) {
+					h = "0" + h;
+				}
+				hexString.append(h);
+			}
+			return hexString.toString();
+		} catch (NoSuchAlgorithmException e) {
+		}
+		return "";
+	}
+
+	public static DisplayMetrics DisplayInfo(Context p_context) {
+		DisplayMetrics metrics = null;
+		try {
+			metrics = new DisplayMetrics();
+			((android.view.WindowManager) p_context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);
+			//p_activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+		} catch (Exception e) {
+		}
+		return metrics;
+	}
+
+	public static double DeviceInches(Context p_context) {
+		double default_value = 4.0f;
+		if (p_context == null)
+			return default_value;
+		try {
+			DisplayMetrics metrics = DisplayInfo(p_context);
+			return Math.sqrt(Math.pow(metrics.widthPixels / metrics.xdpi, 2.0) + Math.pow(metrics.heightPixels / metrics.ydpi, 2.0));
+		} catch (Exception e) {
+			return default_value;
+		}
+	}
+
+	/**
+	 * Executes the request.
+	 * <p/>
+	 * This method is called from the WebView thread.
+	 * <p/>
+	 * To do a non-trivial amount of work, use: cordova.getThreadPool().execute(runnable);
+	 * <p/>
+	 * To run on the UI thread, use: cordova.getActivity().runOnUiThread(runnable);
+	 *
+	 * @param action          The action to execute.
+	 * @param args            The exec() arguments.
+	 * @param callbackContext The callback context used when calling back into JavaScript.
+	 * @return Whether the action was valid.
+	 */
+	@Override
+	public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+		PluginResult result = null;
+
+		if (ACTION_SET_OPTIONS.equals(action)) {
+			JSONObject options = args.optJSONObject(0);
+			result = executeSetOptions(options, callbackContext);
+
+		} else if (ACTION_CREATE_BANNER_VIEW.equals(action)) {
+			JSONObject options = args.optJSONObject(0);
+			result = executeCreateBannerView(options, callbackContext);
+
+		} else if (ACTION_SHOW_BANNER_AD.equals(action)) {
+			boolean show = args.optBoolean(0);
+			result = executeShowBannerAd(show, callbackContext);
+
+		} else if (ACTION_DESTROY_BANNER_VIEW.equals(action)) {
+			result = executeDestroyBannerView(callbackContext);
+
+		} else if (ACTION_REQUEST_INTERSTITIAL_AD.equals(action)) {
+			JSONObject options = args.optJSONObject(0);
+			result = executeRequestInterstitialAd(options, callbackContext);
+
+		} else if (ACTION_SHOW_INTERSTITIAL_AD.equals(action)) {
+			result = executeShowInterstitialAd(callbackContext);
+
+		} else if (ACTION_REQUEST_REWARDED_AD.equals(action)) {
+			JSONObject options = args.optJSONObject(0);
+			result = executeRequestRewardedAd(options, callbackContext);
+
+		} else if (ACTION_SHOW_REWARDED_AD.equals(action)) {
+			result = executeShowRewardedAd(callbackContext);
+		} else if (ACTION_REQUEST_APP_OPEN_AD.equals(action)) {
+			JSONObject options = args.optJSONObject(0);
+			result = executeRequestAppOpenAd(options, callbackContext);
+		} else if (ACTION_SHOW_APP_OPEN_AD.equals(action)) {
+			result = executeShowAppOpenAd(callbackContext);
+		} else {
+			Log.d(ADMOBADS_LOGTAG, String.format("Invalid action passed: %s", action));
+			return false;
+		}
+
+		if (result != null) {
+			callbackContext.sendPluginResult(result);
+		}
+
+		return true;
+	}
 
 
-    /**
-     * Whether or not the ad should be positioned at top or bottom of screen.
-     */
-    private boolean isBannerAtTop = false;
-    /**
-     * Whether or not the banner will overlap the webview instead of push it up or down
-     */
-    private boolean isBannerOverlap = false;
-    private boolean isOffsetStatusBar = false;
-    private boolean isTesting = false;
-    private JSONObject adExtras = null;
-    private boolean isBannerVisible = false;
-    private double tappxShare = 0.5;
-    private boolean hasTappx = false;
+	private PluginResult executeSetOptions(JSONObject options, CallbackContext callbackContext) {
+		Log.w(ADMOBADS_LOGTAG, "executeSetOptions");
+		this.setOptions(options);
+		callbackContext.success();
+		return null;
+	}
 
-    /**
-     * Gets an AdSize object from the string size passed in from JavaScript. Returns null if an improper string is provided.
-     *
-     * @param size The string size representing an ad format constant.
-     * @return An AdSize object used to create a banner.
-     */
-    public static AdSize adSizeFromString(String size) {
-        if ("BANNER".equals(size)) {
-            return AdSize.BANNER;
-        } else if ("IAB_MRECT".equals(size)) {
-            return AdSize.MEDIUM_RECTANGLE;
-        } else if ("IAB_BANNER".equals(size)) {
-            return AdSize.FULL_BANNER;
-        } else if ("IAB_LEADERBOARD".equals(size)) {
-            return AdSize.LEADERBOARD;
-        } else if ("SMART_BANNER".equals(size)) {
-            return AdSize.SMART_BANNER;
-        } else {
-            return AdSize.SMART_BANNER;
-        }
-    }
+	private void setOptions(JSONObject options) {
+		if (options == null) {
+			return;
+		}
+		if (options.has(OPT_APP_ID)) {
+			this.appId = options.optString(OPT_APP_ID);
+		}
+		if (options.has(OPT_PUBLISHER_ID)) {
+			this.publisherId = options.optString(OPT_PUBLISHER_ID);
+		}
+		if (options.has(OPT_INTERSTITIAL_AD_ID)) {
+			this.interstitialAdId = options.optString(OPT_INTERSTITIAL_AD_ID);
+		}
+		if (options.has(OPT_REWARDED_AD_ID)) {
+			this.rewardedAdId = options.optString(OPT_REWARDED_AD_ID);
+		}
+		if (options.has(OPT_APP_OPEN_AD_ID)) {
+			this.appOpenId = options.optString(OPT_APP_OPEN_AD_ID);
+		}
+		if (options.has(OPT_AD_SIZE)) {
+			this.adSize = adSizeFromString(options.optString(OPT_AD_SIZE));
+		}
+		if (options.has(OPT_BANNER_AT_TOP)) {
+			this.isBannerAtTop = options.optBoolean(OPT_BANNER_AT_TOP);
+		}
+		if (options.has(OPT_OVERLAP)) {
+			this.isBannerOverlap = options.optBoolean(OPT_OVERLAP);
+		}
+		if (options.has(OPT_OFFSET_STATUSBAR)) {
+			this.isOffsetStatusBar = options.optBoolean(OPT_OFFSET_STATUSBAR);
+		}
+		if (options.has(OPT_IS_TESTING)) {
+			this.isTesting = options.optBoolean(OPT_IS_TESTING);
+		}
+		if (options.has(OPT_AD_EXTRAS)) {
+			this.adExtras = options.optJSONObject(OPT_AD_EXTRAS);
+		}
+		if (options.has(OPT_AUTO_SHOW_BANNER)) {
+			this.isBannerAutoShow = options.optBoolean(OPT_AUTO_SHOW_BANNER);
+		}
+		if (options.has(OPT_AUTO_SHOW_INTERSTITIAL)) {
+			this.isInterstitialAutoShow = options.optBoolean(OPT_AUTO_SHOW_INTERSTITIAL);
+		}
+		if (options.has(OPT_AUTO_SHOW_REWARDED)) {
+			this.isRewardedAutoShow = options.optBoolean(OPT_AUTO_SHOW_REWARDED);
+		}
+		if (options.has(OPT_TAPPX_ID_ANDROID)) {
+			this.tappxId = options.optString(OPT_TAPPX_ID_ANDROID);
+			hasTappx = true;
+		}
+		if (options.has(OPT_TAPPX_SHARE)) {
+			this.tappxShare = options.optDouble(OPT_TAPPX_SHARE);
+			hasTappx = true;
+		}
+	}
 
-    public static final String md5(final String s) {
-        try {
-            MessageDigest digest = java.security.MessageDigest.getInstance("MD5");
-            digest.update(s.getBytes());
-            byte messageDigest[] = digest.digest();
-            StringBuilder hexString = new StringBuilder();
-            for (byte i : messageDigest) {
-                String h = Integer.toHexString(0xFF & i);
-                while (h.length() < 2) {
-                    h = "0" + h;
-                }
-                hexString.append(h);
-            }
-            return hexString.toString();
-        } catch (NoSuchAlgorithmException e) {
-        }
-        return "";
-    }
-
-    public static DisplayMetrics DisplayInfo(Context p_context) {
-        DisplayMetrics metrics = null;
-        try {
-            metrics = new DisplayMetrics();
-            ((android.view.WindowManager) p_context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);
-            //p_activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
-        } catch (Exception e) {
-        }
-        return metrics;
-    }
-
-    public static double DeviceInches(Context p_context) {
-        double default_value = 4.0f;
-        if (p_context == null)
-            return default_value;
-        try {
-            DisplayMetrics metrics = DisplayInfo(p_context);
-            return Math.sqrt(Math.pow(metrics.widthPixels / metrics.xdpi, 2.0) + Math.pow(metrics.heightPixels / metrics.ydpi, 2.0));
-        } catch (Exception e) {
-            return default_value;
-        }
-    }
-
-    /**
-     * Executes the request.
-     * <p/>
-     * This method is called from the WebView thread.
-     * <p/>
-     * To do a non-trivial amount of work, use: cordova.getThreadPool().execute(runnable);
-     * <p/>
-     * To run on the UI thread, use: cordova.getActivity().runOnUiThread(runnable);
-     *
-     * @param action          The action to execute.
-     * @param args            The exec() arguments.
-     * @param callbackContext The callback context used when calling back into JavaScript.
-     * @return Whether the action was valid.
-     */
-    @Override
-    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-        PluginResult result = null;
-
-        if (ACTION_SET_OPTIONS.equals(action)) {
-            JSONObject options = args.optJSONObject(0);
-            result = executeSetOptions(options, callbackContext);
-
-        } else if (ACTION_CREATE_BANNER_VIEW.equals(action)) {
-            JSONObject options = args.optJSONObject(0);
-            result = executeCreateBannerView(options, callbackContext);
-
-        } else if (ACTION_SHOW_BANNER_AD.equals(action)) {
-            boolean show = args.optBoolean(0);
-            result = executeShowBannerAd(show, callbackContext);
-
-        } else if (ACTION_DESTROY_BANNER_VIEW.equals(action)) {
-            result = executeDestroyBannerView(callbackContext);
-
-        } else if (ACTION_REQUEST_INTERSTITIAL_AD.equals(action)) {
-            JSONObject options = args.optJSONObject(0);
-            result = executeRequestInterstitialAd(options, callbackContext);
-
-        } else if (ACTION_SHOW_INTERSTITIAL_AD.equals(action)) {
-            result = executeShowInterstitialAd(callbackContext);
-
-        }
-        else if (ACTION_REQUEST_REWARDED_AD.equals(action)) {
-            JSONObject options = args.optJSONObject(0);
-            result = executeRequestRewardedAd(options, callbackContext);
-
-        } else if (ACTION_SHOW_REWARDED_AD.equals(action)) {
-            result = executeShowRewardedAd(callbackContext);
-
-        }  else {
-            Log.d(ADMOBADS_LOGTAG, String.format("Invalid action passed: %s", action));
-            return false;
-        }
-
-        if (result != null) {
-            callbackContext.sendPluginResult(result);
-        }
-
-        return true;
-    }
-
-    private PluginResult executeSetOptions(JSONObject options, CallbackContext callbackContext) {
-        Log.w(ADMOBADS_LOGTAG, "executeSetOptions");
-        this.setOptions(options);
-        callbackContext.success();
-        return null;
-    }
-
-    private void setOptions(JSONObject options) {
-        if (options == null) {
-            return;
-        }
-        if (options.has(OPT_APP_ID)) {
-            this.appId = options.optString(OPT_APP_ID);
-        }
-        if (options.has(OPT_PUBLISHER_ID)) {
-            this.publisherId = options.optString(OPT_PUBLISHER_ID);
-        }
-        if (options.has(OPT_INTERSTITIAL_AD_ID)) {
-            this.interstitialAdId = options.optString(OPT_INTERSTITIAL_AD_ID);
-        }
-        if (options.has(OPT_REWARDED_AD_ID)) {
-            this.rewardedAdId = options.optString(OPT_REWARDED_AD_ID);
-        }
-        if (options.has(OPT_AD_SIZE)) {
-            this.adSize = adSizeFromString(options.optString(OPT_AD_SIZE));
-        }
-        if (options.has(OPT_BANNER_AT_TOP)) {
-            this.isBannerAtTop = options.optBoolean(OPT_BANNER_AT_TOP);
-        }
-        if (options.has(OPT_OVERLAP)) {
-            this.isBannerOverlap = options.optBoolean(OPT_OVERLAP);
-        }
-        if (options.has(OPT_OFFSET_STATUSBAR)) {
-            this.isOffsetStatusBar = options.optBoolean(OPT_OFFSET_STATUSBAR);
-        }
-        if (options.has(OPT_IS_TESTING)) {
-            this.isTesting = options.optBoolean(OPT_IS_TESTING);
-        }
-        if (options.has(OPT_AD_EXTRAS)) {
-            this.adExtras = options.optJSONObject(OPT_AD_EXTRAS);
-        }
-        if (options.has(OPT_AUTO_SHOW_BANNER)) {
-            this.isBannerAutoShow = options.optBoolean(OPT_AUTO_SHOW_BANNER);
-        }
-        if (options.has(OPT_AUTO_SHOW_INTERSTITIAL)) {
-            this.isInterstitialAutoShow = options.optBoolean(OPT_AUTO_SHOW_INTERSTITIAL);
-        }  
-        if (options.has(OPT_AUTO_SHOW_REWARDED)) {
-            this.isRewardedAutoShow = options.optBoolean(OPT_AUTO_SHOW_REWARDED);
-        }
-        if (options.has(OPT_TAPPX_ID_ANDROID)) {
-            this.tappxId = options.optString(OPT_TAPPX_ID_ANDROID);
-            hasTappx = true;
-        }
-        if (options.has(OPT_TAPPX_SHARE)) {
-            this.tappxShare = options.optDouble(OPT_TAPPX_SHARE);
-            hasTappx = true;
-        }
-    }
-    
-    private void initializeMobileAds() {
-        String __pid = getPublisherId();
-		if(!isMobileAdsInitialized) {
+	private void initializeMobileAds() {
+		String __pid = getPublisherId();
+		if (!isMobileAdsInitialized) {
 			MobileAds.initialize(cordova.getActivity(), __pid);
 			isMobileAdsInitialized = true;
 		}
 	}
 
-    private PluginResult executeCreateBannerView(JSONObject options, final CallbackContext callbackContext) {
-        this.setOptions(options);
+	private PluginResult executeCreateBannerView(JSONObject options, final CallbackContext callbackContext) {
+		this.setOptions(options);
 
-        String __pid = getPublisherId();
-        if (__pid.length() == 0) {
-            return new PluginResult(Status.ERROR, "bannerAdId is missing");
-        }
+		String __pid = getPublisherId();
+		if (__pid.length() == 0) {
+			return new PluginResult(Status.ERROR, "bannerAdId is missing");
+		}
 
-        final String _pid = __pid;
+		final String _pid = __pid;
 
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                createBannerView(_pid, bannerListener);
-                callbackContext.success();
-            }
-        });
-        return null;
-    }
+		cordova.getActivity().runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
+				createBannerView(_pid, bannerListener);
+				callbackContext.success();
+			}
+		});
+		return null;
+	}
 
-    private void createBannerView(String _pid, AdMobAdsAdListener adListener) {
-        boolean isTappx = _pid.equals(tappxId);
-        initializeMobileAds();
-        if (adView != null && !adView.getAdUnitId().equals(_pid)) {
-            if (adView.getParent() != null) {
-                ((ViewGroup) adView.getParent()).removeView(adView);
-            }
-            adView.destroy();
-            adView = null;
-        }
-        if (adView == null) {
-            adView = new AdView(cordova.getActivity());
-            if (isTappx) {
-                if (adSize == AdSize.BANNER) { // 320x50
-                    adView.setAdSize(adSize);
-                } else if (adSize == AdSize.MEDIUM_RECTANGLE) { // 300x250
-                    _pid = getPublisherId();
-                    adView.setAdSize(adSize);
-                } else if (adSize == AdSize.FULL_BANNER) { // 468x60
-                    adView.setAdSize(AdSize.BANNER);
-                } else if (adSize == AdSize.LEADERBOARD) { // 728x90
-                    adView.setAdSize(AdSize.BANNER);
-                } else if (adSize == AdSize.SMART_BANNER) { // Screen width x 32|50|90
-                    DisplayMetrics metrics = DisplayInfo(AdMobAds.this.cordova.getActivity());
-                    if (metrics.widthPixels >= 768) {
-                        adView.setAdSize(new AdSize(768, 90));
-                    } else {
-                        adView.setAdSize(AdSize.BANNER);
-                    }
-                }
+	private void createBannerView(String _pid, AdMobAdsAdListener adListener) {
+		boolean isTappx = _pid.equals(tappxId);
+		initializeMobileAds();
+		if (adView != null && !adView.getAdUnitId().equals(_pid)) {
+			if (adView.getParent() != null) {
+				((ViewGroup) adView.getParent()).removeView(adView);
+			}
+			adView.destroy();
+			adView = null;
+		}
+		if (adView == null) {
+			adView = new AdView(cordova.getActivity());
+			if (isTappx) {
+				if (adSize == AdSize.BANNER) { // 320x50
+					adView.setAdSize(adSize);
+				} else if (adSize == AdSize.MEDIUM_RECTANGLE) { // 300x250
+					_pid = getPublisherId();
+					adView.setAdSize(adSize);
+				} else if (adSize == AdSize.FULL_BANNER) { // 468x60
+					adView.setAdSize(AdSize.BANNER);
+				} else if (adSize == AdSize.LEADERBOARD) { // 728x90
+					adView.setAdSize(AdSize.BANNER);
+				} else if (adSize == AdSize.SMART_BANNER) { // Screen width x 32|50|90
+					DisplayMetrics metrics = DisplayInfo(AdMobAds.this.cordova.getActivity());
+					if (metrics.widthPixels >= 768) {
+						adView.setAdSize(new AdSize(768, 90));
+					} else {
+						adView.setAdSize(AdSize.BANNER);
+					}
+				}
 
-            } else {
-                adView.setAdSize(adSize);
-            }
-            adView.setAdUnitId(_pid);
-            adView.setAdListener(adListener);
-            adView.setVisibility(View.GONE);
-        }
+			} else {
+				adView.setAdSize(adSize);
+			}
+			adView.setAdUnitId(_pid);
+			adView.setAdListener(adListener);
+			adView.setVisibility(View.GONE);
+		}
 
-        if (adView.getParent() != null) {
-            ((ViewGroup) adView.getParent()).removeView(adView);
-        }
-        isBannerVisible = false;
-        adView.loadAd(buildAdRequest());
-    }
+		if (adView.getParent() != null) {
+			((ViewGroup) adView.getParent()).removeView(adView);
+		}
+		isBannerVisible = false;
+		adView.loadAd(buildAdRequest());
+	}
 
-    @SuppressLint("DefaultLocale")
-    private AdRequest buildAdRequest() {
-        AdRequest.Builder request_builder = new AdRequest.Builder();
-        if (isTesting) {
-            // This will request test ads on the emulator and deviceby passing this hashed device ID.
-            String ANDROID_ID = Settings.Secure.getString(cordova.getActivity().getContentResolver(), android.provider.Settings.Secure.ANDROID_ID);
-            String deviceId = md5(ANDROID_ID).toUpperCase();
-            request_builder = request_builder.addTestDevice(deviceId).addTestDevice(AdRequest.DEVICE_ID_EMULATOR);
-        }
-        Bundle bundle = new Bundle();
-        bundle.putInt("cordova", 1);
-        if (adExtras != null) {
-            Iterator<String> it = adExtras.keys();
-            while (it.hasNext()) {
-                String key = it.next();
-                try {
-                    bundle.putString(key, adExtras.get(key).toString());
-                } catch (JSONException exception) {
-                    Log.w(ADMOBADS_LOGTAG, String.format("Caught JSON Exception: %s", exception.getMessage()));
-                }
-            }
-        }
-        AdMobExtras adextras = new AdMobExtras(bundle);
-        request_builder = request_builder.addNetworkExtras(adextras);
-        AdRequest request = request_builder.build();
-        return request;
-    }
+	@SuppressLint("DefaultLocale")
+	private AdRequest buildAdRequest() {
+		AdRequest.Builder request_builder = new AdRequest.Builder();
+		if (isTesting) {
+			// This will request test ads on the emulator and deviceby passing this hashed device ID.
+			String ANDROID_ID = Settings.Secure.getString(cordova.getActivity().getContentResolver(), android.provider.Settings.Secure.ANDROID_ID);
+			String deviceId = md5(ANDROID_ID).toUpperCase();
+			request_builder = request_builder.addTestDevice(deviceId).addTestDevice(AdRequest.DEVICE_ID_EMULATOR);
+		}
+		Bundle bundle = new Bundle();
+		bundle.putInt("cordova", 1);
+		if (adExtras != null) {
+			Iterator<String> it = adExtras.keys();
+			while (it.hasNext()) {
+				String key = it.next();
+				try {
+					bundle.putString(key, adExtras.get(key).toString());
+				} catch (JSONException exception) {
+					Log.w(ADMOBADS_LOGTAG, String.format("Caught JSON Exception: %s", exception.getMessage()));
+				}
+			}
+		}
+		AdMobExtras adextras = new AdMobExtras(bundle);
+		request_builder = request_builder.addNetworkExtras(adextras);
+		AdRequest request = request_builder.build();
+		return request;
+	}
 
-    /**
-     * Parses the show ad input parameters and runs the show ad action on the UI thread.
-     *
-     * @param show indicates if the banner should be shown or not.
-     * @param callbackContext Callback to be called when thread finishes.
-     * @return A PluginResult representing whether or not an ad was requested succcessfully. Listen for onReceiveAd() and onFailedToReceiveAd() callbacks to see
-     * if an ad was successfully retrieved.
-     */
-    private PluginResult executeShowBannerAd(final boolean show, final CallbackContext callbackContext) {
-        if (adView == null) {
-            return new PluginResult(Status.ERROR, "adView is null, call createBannerView first.");
-        }
+	/**
+	 * Parses the show ad input parameters and runs the show ad action on the UI thread.
+	 *
+	 * @param show            indicates if the banner should be shown or not.
+	 * @param callbackContext Callback to be called when thread finishes.
+	 * @return A PluginResult representing whether or not an ad was requested succcessfully. Listen for onReceiveAd() and onFailedToReceiveAd() callbacks to see
+	 * if an ad was successfully retrieved.
+	 */
+	private PluginResult executeShowBannerAd(final boolean show, final CallbackContext callbackContext) {
+		if (adView == null) {
+			return new PluginResult(Status.ERROR, "adView is null, call createBannerView first.");
+		}
 
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                if (show == isBannerVisible) {
-                    // no change
+		cordova.getActivity().runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
+				if (show == isBannerVisible) {
+					// no change
 
-                } else if (show) {
-                    if (adView.getParent() != null) {
-                        ((ViewGroup) adView.getParent()).removeView(adView);
-                    }
+				} else if (show) {
+					if (adView.getParent() != null) {
+						((ViewGroup) adView.getParent()).removeView(adView);
+					}
 
-                    if (isBannerOverlap) {
-                        RelativeLayout.LayoutParams params2 = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
+					if (isBannerOverlap) {
+						RelativeLayout.LayoutParams params2 = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
 
-                        if (isOffsetStatusBar) {
-                            int titleBarHeight = 0;
-                            Rect rectangle = new Rect();
-                            Window window = AdMobAds.this.cordova.getActivity().getWindow();
-                            window.getDecorView().getWindowVisibleDisplayFrame(rectangle);
+						if (isOffsetStatusBar) {
+							int titleBarHeight = 0;
+							Rect rectangle = new Rect();
+							Window window = AdMobAds.this.cordova.getActivity().getWindow();
+							window.getDecorView().getWindowVisibleDisplayFrame(rectangle);
 
-                            if (isBannerAtTop) {
-                                if (rectangle.top == 0) {
-                                    int contentViewTop = window.findViewById(Window.ID_ANDROID_CONTENT).getTop();
-                                    titleBarHeight = contentViewTop - rectangle.top;
-                                }
-                                params2.topMargin = titleBarHeight;
+							if (isBannerAtTop) {
+								if (rectangle.top == 0) {
+									int contentViewTop = window.findViewById(Window.ID_ANDROID_CONTENT).getTop();
+									titleBarHeight = contentViewTop - rectangle.top;
+								}
+								params2.topMargin = titleBarHeight;
 
-                            } else {
-                                if (rectangle.top > 0) {
-                                    int contentViewBottom = window.findViewById(Window.ID_ANDROID_CONTENT).getBottom();
-                                    titleBarHeight = contentViewBottom - rectangle.bottom;
-                                }
-                                params2.bottomMargin = titleBarHeight;
-                            }
+							} else {
+								if (rectangle.top > 0) {
+									int contentViewBottom = window.findViewById(Window.ID_ANDROID_CONTENT).getBottom();
+									titleBarHeight = contentViewBottom - rectangle.bottom;
+								}
+								params2.bottomMargin = titleBarHeight;
+							}
 
-                        } else if (isBannerAtTop) {
-                            params2.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+						} else if (isBannerAtTop) {
+							params2.addRule(RelativeLayout.ALIGN_PARENT_TOP);
 
-                        } else {
-                            params2.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
-                        }
+						} else {
+							params2.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+						}
 
-                        if (adViewLayout == null) {
-                            adViewLayout = new RelativeLayout(cordova.getActivity());
-                            RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
-                            if (CORDOVA_4) {
-                                ((ViewGroup) webView.getView().getParent()).addView(adViewLayout, params);
-                            } else {
-                                ((ViewGroup) webView).addView(adViewLayout, params);
-                            }
-                        }
-                        adViewLayout.addView(adView, params2);
-                        adViewLayout.bringToFront();
+						if (adViewLayout == null) {
+							adViewLayout = new RelativeLayout(cordova.getActivity());
+							RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
+							if (CORDOVA_4) {
+								((ViewGroup) webView.getView().getParent()).addView(adViewLayout, params);
+							} else {
+								((ViewGroup) webView).addView(adViewLayout, params);
+							}
+						}
+						adViewLayout.addView(adView, params2);
+						adViewLayout.bringToFront();
 
-                    } else {
-                        if (CORDOVA_4) {
-                            ViewGroup wvParentView = (ViewGroup) webView.getView().getParent();
+					} else {
+						if (CORDOVA_4) {
+							ViewGroup wvParentView = (ViewGroup) webView.getView().getParent();
 
-                            if (parentView == null) {
-                                parentView = new LinearLayout(webView.getContext());
-                            }
+							if (parentView == null) {
+								parentView = new LinearLayout(webView.getContext());
+							}
 
-                            if (wvParentView != null && wvParentView != parentView) {
-                                wvParentView.removeView(webView.getView());
-                                ((LinearLayout) parentView).setOrientation(LinearLayout.VERTICAL);
-                                parentView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT, 0.0F));
-                                webView.getView().setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT, 1.0F));
-                                parentView.addView(webView.getView());
-                                cordova.getActivity().setContentView(parentView);
-                            }
+							if (wvParentView != null && wvParentView != parentView) {
+								wvParentView.removeView(webView.getView());
+								((LinearLayout) parentView).setOrientation(LinearLayout.VERTICAL);
+								parentView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT, 0.0F));
+								webView.getView().setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT, 1.0F));
+								parentView.addView(webView.getView());
+								cordova.getActivity().setContentView(parentView);
+							}
 
-                        } else {
-                            parentView = (ViewGroup) ((ViewGroup) webView).getParent();
-                        }
+						} else {
+							parentView = (ViewGroup) ((ViewGroup) webView).getParent();
+						}
 
-                        if (isBannerAtTop) {
-                            parentView.addView(adView, 0);
-                        } else {
-                            parentView.addView(adView);
-                        }
-                        parentView.bringToFront();
-                        parentView.requestLayout();
+						if (isBannerAtTop) {
+							parentView.addView(adView, 0);
+						} else {
+							parentView.addView(adView);
+						}
+						parentView.bringToFront();
+						parentView.requestLayout();
 
-                    }
+					}
 
-                    adView.setVisibility(View.VISIBLE);
-                    isBannerVisible = true;
+					adView.setVisibility(View.VISIBLE);
+					isBannerVisible = true;
 
-                } else {
-                    adView.setVisibility(View.GONE);
-                    isBannerVisible = false;
-                }
+				} else {
+					adView.setVisibility(View.GONE);
+					isBannerVisible = false;
+				}
 
-                if (callbackContext != null) {
-                    callbackContext.success();
-                }
-            }
-        });
-        return null;
-    }
+				if (callbackContext != null) {
+					callbackContext.success();
+				}
+			}
+		});
+		return null;
+	}
 
-    private PluginResult executeDestroyBannerView(CallbackContext callbackContext) {
-        Log.w(ADMOBADS_LOGTAG, "executeDestroyBannerView");
-        final CallbackContext delayCallback = callbackContext;
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                if (adView != null) {
-                    ViewGroup parentView = (ViewGroup) adView.getParent();
-                    if (parentView != null) {
-                        parentView.removeView(adView);
-                    }
-                    adView.destroy();
-                    adView = null;
-                }
-                isBannerVisible = false;
-                delayCallback.success();
-            }
-        });
-        return null;
-    }
+	private PluginResult executeDestroyBannerView(CallbackContext callbackContext) {
+		Log.w(ADMOBADS_LOGTAG, "executeDestroyBannerView");
+		final CallbackContext delayCallback = callbackContext;
+		cordova.getActivity().runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
+				if (adView != null) {
+					ViewGroup parentView = (ViewGroup) adView.getParent();
+					if (parentView != null) {
+						parentView.removeView(adView);
+					}
+					adView.destroy();
+					adView = null;
+				}
+				isBannerVisible = false;
+				delayCallback.success();
+			}
+		});
+		return null;
+	}
 
-    private PluginResult executeCreateInterstitialView(JSONObject options, final CallbackContext callbackContext) {
-        this.setOptions(options);
+	private PluginResult executeCreateInterstitialView(JSONObject options, final CallbackContext callbackContext) {
+		this.setOptions(options);
 
-        String __iid = getInterstitialId();
+		String __iid = getInterstitialId();
 
-        if (__iid.length() == 0) {
-            return new PluginResult(Status.ERROR, "interstitialAdId is missing");
-        }
+		if (__iid.length() == 0) {
+			return new PluginResult(Status.ERROR, "interstitialAdId is missing");
+		}
 
 
-        final String _iid = __iid;
-        
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
+		final String _iid = __iid;
 
-                createInterstitialView(_iid, interstitialListener);
-                callbackContext.success();
-            }
-        });
-        return null;
-    }
+		cordova.getActivity().runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
 
-    private void createInterstitialView(String _iid, AdMobAdsAdListener adListener) {
-        initializeMobileAds();
+				createInterstitialView(_iid, interstitialListener);
+				callbackContext.success();
+			}
+		});
+		return null;
+	}
 
-        interstitialAd = new InterstitialAd(cordova.getActivity());
-        interstitialAd.setAdUnitId(_iid);
-       
-        interstitialAd.setAdListener(adListener);
-        interstitialAd.loadAd(buildAdRequest());
-    }
+	private void createInterstitialView(String _iid, AdMobAdsAdListener adListener) {
+		initializeMobileAds();
 
-    private PluginResult executeRequestInterstitialAd(JSONObject options, final CallbackContext callbackContext) {
-        if (isInterstitialAvailable) {
-            interstitialListener.onAdLoaded();
-            callbackContext.success();
+		interstitialAd = new InterstitialAd(cordova.getActivity());
+		interstitialAd.setAdUnitId(_iid);
 
-        } else {
-            this.setOptions(options);
-            if (interstitialAd == null) {
-                return executeCreateInterstitialView(options, callbackContext);
+		interstitialAd.setAdListener(adListener);
+		interstitialAd.loadAd(buildAdRequest());
+	}
 
-            } else {
-                cordova.getActivity().runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        interstitialAd.loadAd(buildAdRequest());
-                        callbackContext.success();
-                    }
-                });
-            }
-        }
-        return null;
-    }
+	private PluginResult executeRequestInterstitialAd(JSONObject options, final CallbackContext callbackContext) {
+		if (isInterstitialAvailable) {
+			interstitialListener.onAdLoaded();
+			callbackContext.success();
 
-    private PluginResult executeShowInterstitialAd(CallbackContext callbackContext) {
-        return showInterstitialAd(callbackContext);
-    }
+		} else {
+			this.setOptions(options);
+			if (interstitialAd == null) {
+				return executeCreateInterstitialView(options, callbackContext);
 
-    protected PluginResult showInterstitialAd(final CallbackContext callbackContext) {
-        if (interstitialAd == null) {
-            return new PluginResult(Status.ERROR, "interstitialAd is null, call createInterstitialView first.");
-        }
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                if (interstitialAd.isLoaded()) {
-                    interstitialAd.show();
-                }
-                if (callbackContext != null) {
-                    callbackContext.success();
-                }
-            }
-        });
-        return null;
-    }
+			} else {
+				cordova.getActivity().runOnUiThread(new Runnable() {
+					@Override
+					public void run() {
+						interstitialAd.loadAd(buildAdRequest());
+						callbackContext.success();
+					}
+				});
+			}
+		}
+		return null;
+	}
+
+	private PluginResult executeRequestAppOpenAd(JSONObject options, CallbackContext callbackContext) {
+		if (isOpenAdAvailable()) {
+			callbackContext.success();
+		} else {
+			this.setOptions(options);
+			cordova.getActivity().runOnUiThread(new Runnable() {
+				@Override
+				public void run() {
+					loadAppOpenAd();
+				}
+			});
+		}
+
+		return null;
+	}
+
+	private PluginResult executeShowAppOpenAd(CallbackContext callbackContext) {
+		return showOpenAdIfAvailable(callbackContext);
+	}
+
+	private PluginResult executeShowInterstitialAd(CallbackContext callbackContext) {
+		return showInterstitialAd(callbackContext);
+	}
+
+	protected PluginResult showInterstitialAd(final CallbackContext callbackContext) {
+		if (interstitialAd == null) {
+			return new PluginResult(Status.ERROR, "interstitialAd is null, call createInterstitialView first.");
+		}
+		cordova.getActivity().runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
+				if (interstitialAd.isLoaded()) {
+					interstitialAd.show();
+				}
+				if (callbackContext != null) {
+					callbackContext.success();
+				}
+			}
+		});
+		return null;
+	}
 
 ///////////////////Rewarded Ads///////////////////////
 
-    private PluginResult executeCreateRewardedView(JSONObject options, final CallbackContext callbackContext) {
-        this.setOptions(options);
-        String __iid = getRewardedId();
+	private PluginResult executeCreateRewardedView(JSONObject options, final CallbackContext callbackContext) {
+		this.setOptions(options);
+		String __iid = getRewardedId();
 
-        if (__iid.length() == 0) {
-            return new PluginResult(Status.ERROR, "rewardedAdId is missing");
-        }
+		if (__iid.length() == 0) {
+			return new PluginResult(Status.ERROR, "rewardedAdId is missing");
+		}
 
-        final String _iid = __iid;
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
+		final String _iid = __iid;
+		cordova.getActivity().runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
 
-                createRewardedView(_iid, rewardedListener);
-                callbackContext.success();
-            }
-        });
-        return null;
-    }
+				createRewardedView(_iid, rewardedListener);
+				callbackContext.success();
+			}
+		});
+		return null;
+	}
 
-    private void createRewardedView(String _iid, AdMobRewardedVideoAdListener adListener) {
-        initializeMobileAds();
+	private void createRewardedView(String _iid, AdMobRewardedVideoAdListener adListener) {
+		initializeMobileAds();
 
-        rewardedAd = MobileAds.getRewardedVideoAdInstance(cordova.getActivity());
-        
-        rewardedAd.setRewardedVideoAdListener(adListener);
-        rewardedAd.loadAd(_iid,buildAdRequest());
-    }
+		rewardedAd = MobileAds.getRewardedVideoAdInstance(cordova.getActivity());
 
-    private PluginResult executeRequestRewardedAd(JSONObject options, final CallbackContext callbackContext) {
-       final String __iid = getRewardedId();
+		rewardedAd.setRewardedVideoAdListener(adListener);
+		rewardedAd.loadAd(_iid, buildAdRequest());
+	}
 
-        if (isRewardedAvailable) {
-            rewardedListener.onRewardedVideoAdLoaded();
-            callbackContext.success();
+	private PluginResult executeRequestRewardedAd(JSONObject options, final CallbackContext callbackContext) {
+		final String __iid = getRewardedId();
 
-        } else {
-            this.setOptions(options);
-            if (rewardedAd == null) {
-                return executeCreateRewardedView(options, callbackContext);
+		if (isRewardedAvailable) {
+			rewardedListener.onRewardedVideoAdLoaded();
+			callbackContext.success();
 
-            } else {
-                cordova.getActivity().runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        rewardedAd.loadAd(__iid,buildAdRequest());
-                        callbackContext.success();
-                    }
-                });
-            }
-        }
-        return null;
-    }
+		} else {
+			this.setOptions(options);
+			if (rewardedAd == null) {
+				return executeCreateRewardedView(options, callbackContext);
 
-    private PluginResult executeShowRewardedAd(CallbackContext callbackContext) {
-        return showRewardedAd(callbackContext);
-    }
+			} else {
+				cordova.getActivity().runOnUiThread(new Runnable() {
+					@Override
+					public void run() {
+						rewardedAd.loadAd(__iid, buildAdRequest());
+						callbackContext.success();
+					}
+				});
+			}
+		}
+		return null;
+	}
 
-    protected PluginResult showRewardedAd(final CallbackContext callbackContext) {
-        if (rewardedAd == null) {
-            return new PluginResult(Status.ERROR, "rewardedAd is null, call createRewardedView first.");
-        }
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                if (rewardedAd.isLoaded()) {
-                    rewardedAd.show();
-                }
-                if (callbackContext != null) {
-                    callbackContext.success();
-                }
-            }
-        });
-        return null;
-    }
+	private PluginResult executeShowRewardedAd(CallbackContext callbackContext) {
+		return showRewardedAd(callbackContext);
+	}
 
+	protected PluginResult showRewardedAd(final CallbackContext callbackContext) {
+		if (rewardedAd == null) {
+			return new PluginResult(Status.ERROR, "rewardedAd is null, call createRewardedView first.");
+		}
+		cordova.getActivity().runOnUiThread(new Runnable() {
+			@Override
+			public void run() {
+				if (rewardedAd.isLoaded()) {
+					rewardedAd.show();
+				}
+				if (callbackContext != null) {
+					callbackContext.success();
+				}
+			}
+		});
+		return null;
+	}
 
+	@Override
+	public void onPause(boolean multitasking) {
+		super.onPause(multitasking);
+		if (adView != null) {
+			adView.pause();
+		}
+		if (rewardedAd != null) {
+			rewardedAd.pause(cordova.getActivity());
+		}
+	}
 
+	@Override
+	public void onResume(boolean multitasking) {
+		super.onResume(multitasking);
+		if (adView != null) {
+			adView.resume();
+		}
+		if (rewardedAd != null) {
+			rewardedAd.resume(cordova.getActivity());
+		}
+	}
 
+	@Override
+	public void onDestroy() {
+		if (adView != null) {
+			adView.destroy();
+			adView = null;
+		}
+		if (adViewLayout != null) {
+			ViewGroup parentView = (ViewGroup) adViewLayout.getParent();
+			if (parentView != null) {
+				parentView.removeView(adViewLayout);
+			}
+			adViewLayout = null;
+		}
+		super.onDestroy();
+	}
 
+	private String getAppId() {
+		return appId;
+	}
 
+	private String getPublisherId() {
+		return getPublisherId(hasTappx);
+	}
 
+	private String getPublisherId(boolean hasTappx) {
+		String _publisherId = publisherId;
 
-    @Override
-    public void onPause(boolean multitasking) {
-        super.onPause(multitasking);
-        if (adView != null) {
-            adView.pause();
-        }
-        if(rewardedAd != null){
-            rewardedAd.pause(cordova.getActivity());
-        }
-    }
+		//Check for Tappx
+		if (hasTappx && (new Random()).nextInt(100) <= (int) (tappxShare * 100) && tappxId != null && tappxId.length() > 0) {
+			_publisherId = tappxId;
+		}
 
-    @Override
-    public void onResume(boolean multitasking) {
-        super.onResume(multitasking);
-        if (adView != null) {
-            adView.resume();
-        }
-        if(rewardedAd != null){
-            rewardedAd.resume(cordova.getActivity());
-        }
-    }
+		return _publisherId;
+	}
 
-    @Override
-    public void onDestroy() {
-        if (adView != null) {
-            adView.destroy();
-            adView = null;
-        }
-        if (adViewLayout != null) {
-            ViewGroup parentView = (ViewGroup) adViewLayout.getParent();
-            if (parentView != null) {
-                parentView.removeView(adViewLayout);
-            }
-            adViewLayout = null;
-        }
-        super.onDestroy();
-    }
+	private String getInterstitialId() {
+		String _interstitialAdId = interstitialAdId;
 
-    private String getAppId() {
-        return appId;
-    }
-    
-    private String getPublisherId() {
-        return getPublisherId(hasTappx);
-    }
+		//Check for Tappx
+		if (hasTappx && (new Random()).nextInt(100) <= (int) (tappxShare * 100) && tappxId != null && tappxId.length() > 0) {
+			_interstitialAdId = tappxId;
+		}
 
-    private String getPublisherId(boolean hasTappx) {
-        String _publisherId = publisherId;
+		return _interstitialAdId;
+	}
 
-        //Check for Tappx
-        if (hasTappx && (new Random()).nextInt(100) <= (int) (tappxShare * 100) && tappxId != null && tappxId.length() > 0) {
-            _publisherId = tappxId;
-        }
-
-        return _publisherId;
-    }
-
-    private String getInterstitialId() {
-        String _interstitialAdId = interstitialAdId;
-
-        //Check for Tappx
-        if (hasTappx && (new Random()).nextInt(100) <= (int) (tappxShare * 100) && tappxId != null && tappxId.length() > 0) {
-            _interstitialAdId = tappxId;
-        }
-
-        return _interstitialAdId;
-    }
-    private String getRewardedId() {
-        String _rewardedAdId = rewardedAdId;
+	private String getRewardedId() {
+		String _rewardedAdId = rewardedAdId;
 
 
-        return _rewardedAdId;
-    }
+		return _rewardedAdId;
+	}
 
-    public void onAdLoaded(String adType) {
-        if (INTERSTITIAL.equalsIgnoreCase(adType)) {
-            isInterstitialAvailable = true;
-            if (isInterstitialAutoShow) {
-                showInterstitialAd(null);
-            }
-        } else if (BANNER.equalsIgnoreCase(adType)) {
-            if (isBannerAutoShow) {
-                executeShowBannerAd(true, null);
-                bannerListener.onAdOpened();
-            }
-        }else if (REWARDED.equalsIgnoreCase(adType)) {
-            if (isRewardedAutoShow) {
-                showRewardedAd(null);
-            }
-        }
-    }
+	private boolean isOpenAdAvailable() {
+		return appOpenAd != null;
+	}
 
-    public void onAdOpened(String adType) {
-        if (INTERSTITIAL.equalsIgnoreCase(adType)) {
-            isInterstitialAvailable = false;
-        }
-        if (REWARDED.equalsIgnoreCase(adType)) {
-            isRewardedAvailable = false;
-        }
-    }
+	private void loadAppOpenAd() {
+		if (isOpenAdAvailable()) {
+			return;
+		}
+
+		loadCallback = new AppOpenAd.AppOpenAdLoadCallback() {
+			@Override
+			public void onAppOpenAdLoaded(AppOpenAd ad) {
+				appOpenAd = ad;
+				appOpenListener.onAdLoaded();
+			}
+
+			@Override
+			public void onAppOpenAdFailedToLoad(LoadAdError loadAdError) {
+				Log.d(ADMOBADS_LOGTAG, "App open ad failed to load");
+				appOpenListener.onAdFailedToLoad(loadAdError.getCode());
+			}
+		};
+		AdRequest request = new AdRequest.Builder().build();
+		AppOpenAd.load(cordova.getContext(), appOpenId, request, AppOpenAd.APP_OPEN_AD_ORIENTATION_PORTRAIT, loadCallback);
+	}
+
+	private PluginResult showOpenAdIfAvailable(CallbackContext callbackContext) {
+		if (!isShowingAppOpenAd && isOpenAdAvailable()) {
+			Log.d(ADMOBADS_LOGTAG, "Going to show app open ad");
+			FullScreenContentCallback fullScreenContentCallback = new FullScreenContentCallback() {
+				@Override
+				public void onAdDismissedFullScreenContent() {
+					appOpenAd = null;
+					isShowingAppOpenAd = false;
+					appOpenListener.onAdClosed();
+				}
+
+				@Override
+				public void onAdFailedToShowFullScreenContent(AdError adError) {
+					appOpenListener.onAdFailedToLoad(adError.getCode());
+				}
+
+				@Override
+				public void onAdShowedFullScreenContent() {
+					isShowingAppOpenAd = true;
+					appOpenListener.onAdOpened();
+				}
+			};
+			cordova.getActivity().runOnUiThread(new Runnable() {
+				@Override
+				public void run() {
+					appOpenAd.show(cordova.getActivity(), fullScreenContentCallback);
+					if (callbackContext != null) {
+						callbackContext.success();
+					}
+				}
+			});
+
+		} else {
+			return new PluginResult(Status.ERROR, "App Open Ad not loaded, call requestAppOpenAd first.");
+		}
+		return null;
+	}
+
+	public void onAdLoaded(String adType) {
+		if (INTERSTITIAL.equalsIgnoreCase(adType)) {
+			isInterstitialAvailable = true;
+			if (isInterstitialAutoShow) {
+				showInterstitialAd(null);
+			}
+		} else if (BANNER.equalsIgnoreCase(adType)) {
+			if (isBannerAutoShow) {
+				executeShowBannerAd(true, null);
+				bannerListener.onAdOpened();
+			}
+		} else if (REWARDED.equalsIgnoreCase(adType)) {
+			if (isRewardedAutoShow) {
+				showRewardedAd(null);
+			}
+		}
+	}
+
+	public void onAdOpened(String adType) {
+		if (INTERSTITIAL.equalsIgnoreCase(adType)) {
+			isInterstitialAvailable = false;
+		}
+		if (REWARDED.equalsIgnoreCase(adType)) {
+			isRewardedAvailable = false;
+		}
+	}
 }

--- a/src/ios/CDVAdMobAds.h
+++ b/src/ios/CDVAdMobAds.h
@@ -44,6 +44,7 @@
 @class GADInterstitial;
 @class GADRewardAd;
 @class CDVAdMobAdsAdListener;
+@class GADAppOpenAd;
 
 #pragma mark AdMobAds Plugin
 
@@ -52,15 +53,18 @@
 
 @property (assign) BOOL isInterstitialAvailable;
 @property (assign) BOOL isRewardedAvailable;
+@property (assign) BOOL isAppOpenAvailable;
 
 @property (nonatomic, retain) GADBannerView *bannerView;
 @property (nonatomic, retain) GADInterstitial *interstitialView;
 @property (nonatomic, retain) GADRewardedAd *rewardedView;
+@property (nonatomic, retain) GADAppOpenAd* appOpenAd;
 @property (nonatomic, retain) CDVAdMobAdsAdListener *adsListener;
 
-@property (nonatomic, retain) NSString* publisherId;
+@property (nonatomic, retain) NSString* bannerAdId;
 @property (nonatomic, retain) NSString* interstitialAdId;
 @property (nonatomic, retain) NSString* rewardedAdId;
+@property (nonatomic, retain) NSString* appOpenAdId;
 @property (nonatomic, retain) NSString* tappxId;
 
 @property (assign) GADAdSize adSize;
@@ -92,8 +96,12 @@
 - (void)requestRewardedAd:(CDVInvokedUrlCommand *)command;
 - (void)showRewardedAd:(CDVInvokedUrlCommand *)command;
 
+- (void)requestAppOpenAd:(CDVInvokedUrlCommand *)command;
+- (void)showAppOpenAd:(CDVInvokedUrlCommand *)command;
+
 - (void)onBannerAd:(GADBannerView *)adView adListener:(CDVAdMobAdsAdListener *)adListener ;
 - (void)onInterstitialAd:(GADInterstitial *)interstitial adListener:(CDVAdMobAdsAdListener *)adListener;
 - (void)onRewardedAd:(GADRewardedAd *)rewarded adListener:(CDVAdMobAdsAdListener *)adListener;
+- (void)onAppOpenAd:(GADAppOpenAd *)appOpenAd adListener:(CDVAdMobAdsAdListener *)adListener;
 
 @end

--- a/src/ios/CDVAdMobAdsAdListener.h
+++ b/src/ios/CDVAdMobAdsAdListener.h
@@ -34,7 +34,7 @@
 
 @class CDVAdMobAds;
 
-@interface CDVAdMobAdsAdListener : NSObject <GADRewardedAdDelegate,GADBannerViewDelegate, GADInterstitialDelegate> {
+@interface CDVAdMobAdsAdListener : NSObject <GADRewardedAdDelegate,GADBannerViewDelegate, GADInterstitialDelegate, GADFullScreenPresentingAd> {
     
 }
 
@@ -46,4 +46,5 @@
 - (void)interstitialDidFailedToShow:(GADInterstitial *) interstitial;
 - (void)rewardedDidFailedToShow:(GADRewardedAd *) rewarded;
 - (void)rewardAdDidReceiveAd:(GADRewardedAd *) rewarded;
+- (void)appOpenDidReceiveAd:(GADAppOpenAd *)appOpenAd;
 @end

--- a/src/ios/CDVAdMobAdsAdListener.m
+++ b/src/ios/CDVAdMobAdsAdListener.m
@@ -47,6 +47,13 @@
     return self;
 }
 
+- (void)appOpenDidReceiveAd:(GADAppOpenAd *)appOpenAd {
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        [adMobAds.commandDelegate evalJs:@"setTimeout(function (){ cordova.fireDocumentEvent(admob.events.onAdLoaded, { 'adType' : 'app_open' }); }, 1);"];
+    }];
+    [adMobAds onAppOpenAd:appOpenAd adListener:self];
+}
+
 #pragma mark -
 #pragma mark GADBannerViewDelegate implementation
 

--- a/www/admob.js
+++ b/www/admob.js
@@ -2,19 +2,19 @@
  admob.js
  Copyright 2014 AppFeel. All rights reserved.
  http://www.appfeel.com
-
+	
  AdMobAds Cordova Plugin (cordova-admob)
-
+	
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to
  deal in the Software without restriction, including without limitation the
  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
  sell copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+	
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
-
+	
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,14 +29,14 @@ var admob = window.admob || {};
  * This enum represents appfeel-cordova-admob plugin events
  */
 admob.events = {
-  onAdLoaded: "appfeel.cordova.admob.onAdLoaded",
-  onAdFailedToLoad: "appfeel.cordova.admob.onAdFailedToLoad",
-  onAdOpened: "appfeel.cordova.admob.onAdOpened",
-  onAdLeftApplication: "appfeel.cordova.admob.onAdLeftApplication",
-  onAdClosed: "appfeel.cordova.admob.onAdClosed",
-  onAdRewarded: "appfeel.cordova.admob.onAdRewarded", 
-  onAdStarted: "appfeel.cordova.admob.onAdStarted",
-  onInAppPurchaseRequested: "appfeel.cordova.admob.onInAppPurchaseRequested",
+	onAdLoaded: "appfeel.cordova.admob.onAdLoaded",
+	onAdFailedToLoad: "appfeel.cordova.admob.onAdFailedToLoad",
+	onAdOpened: "appfeel.cordova.admob.onAdOpened",
+	onAdLeftApplication: "appfeel.cordova.admob.onAdLeftApplication",
+	onAdClosed: "appfeel.cordova.admob.onAdClosed",
+	onAdRewarded: "appfeel.cordova.admob.onAdRewarded",
+	onAdStarted: "appfeel.cordova.admob.onAdStarted",
+	onInAppPurchaseRequested: "appfeel.cordova.admob.onInAppPurchaseRequested",
 };
 
 /**
@@ -45,40 +45,42 @@ admob.events = {
  * @const
  */
 admob.AD_SIZE = {
-  BANNER: 'BANNER',
-  IAB_MRECT: 'IAB_MRECT',
-  IAB_BANNER: 'IAB_BANNER',
-  IAB_LEADERBOARD: 'IAB_LEADERBOARD',
-  SMART_BANNER: 'SMART_BANNER'
+	BANNER: 'BANNER',
+	IAB_MRECT: 'IAB_MRECT',
+	IAB_BANNER: 'IAB_BANNER',
+	IAB_LEADERBOARD: 'IAB_LEADERBOARD',
+	SMART_BANNER: 'SMART_BANNER'
 };
 
 admob.AD_TYPE = {
-  BANNER: 'banner',
-  INTERSTITIAL: 'interstitial',
-  REWARDED: 'rewarded'
+	BANNER: 'banner',
+	INTERSTITIAL: 'interstitial',
+	REWARDED: 'rewarded',
+	APP_OPEN: 'app_open'
 };
 
 admob.PURCHASE_RESOLUTION = {
-  RESOLUTION_CANCELED: 2,
-  RESOLUTION_FAILURE: 0,
-  RESOLUTION_INVALID_PRODUCT: 3,
-  RESOLUTION_SUCCESS: 1
+	RESOLUTION_CANCELED: 2,
+	RESOLUTION_FAILURE: 0,
+	RESOLUTION_INVALID_PRODUCT: 3,
+	RESOLUTION_SUCCESS: 1
 };
 
 // This is not used by the plugin, it is just a helper to show how options are specified and their default values
 admob.options = {
-  appId: "",
-  bannerAdId: "",
-  interstitialAdId: "",
-  adSize: admob.AD_SIZE.SMART_BANNER,
-  bannerAtTop: false,
-  overlap: false,
-  offsetStatusBar: false,
-  isTesting: false,
-  adExtras: {},
-  autoShowBanner: true,
-  autoShowInterstitial: true,
-  autoShowRewarded: false
+	appId: "",
+	bannerAdId: "",
+	interstitialAdId: "",
+	appOpenAdId: "",
+	adSize: admob.AD_SIZE.SMART_BANNER,
+	bannerAtTop: false,
+	overlap: false,
+	offsetStatusBar: false,
+	isTesting: false,
+	adExtras: {},
+	autoShowBanner: true,
+	autoShowInterstitial: true,
+	autoShowRewarded: false
 };
 
 /**
@@ -88,27 +90,27 @@ admob.options = {
  * @param {function()} failureCallback Callback on fail
  */
 admob.setOptions = function (options, successCallback, failureCallback) {
-  if (typeof options === 'function') {
-    failureCallback = successCallback;
-    successCallback = options;
-    options = undefined;
-  }
-  
-  // Migrate publisherId => bannerAdId
-  if(typeof options === 'object' && options.publisherId != undefined) {
-	  options.bannerAdId = options.publisherId;
-  }
+	if (typeof options === 'function') {
+		failureCallback = successCallback;
+		successCallback = options;
+		options = undefined;
+	}
 
-  options = options || admob.DEFAULT_OPTIONS;
+	// Migrate publisherId => bannerAdId
+	if (typeof options === 'object' && options.publisherId != undefined) {
+		options.bannerAdId = options.publisherId;
+	}
 
-  if (typeof options === 'object') {
-    cordova.exec(successCallback, failureCallback, 'AdMobAds', 'setOptions', [options]);
+	options = options || admob.DEFAULT_OPTIONS;
 
-  } else {
-    if (typeof failureCallback === 'function') {
-      failureCallback('options.appId should be specified.');
-    }
-  }
+	if (typeof options === 'object') {
+		cordova.exec(successCallback, failureCallback, 'AdMobAds', 'setOptions', [options]);
+
+	} else {
+		if (typeof failureCallback === 'function') {
+			failureCallback('options.appId should be specified.');
+		}
+	}
 };
 
 /**
@@ -119,13 +121,13 @@ admob.setOptions = function (options, successCallback, failureCallback) {
  * @param {function()} failureCallback The function to call if create banner  was unsuccessful.
  */
 admob.createBannerView = function (options, successCallback, failureCallback) {
-  if (typeof options === 'function') {
-    failureCallback = successCallback;
-    successCallback = options;
-    options = undefined;
-  }
-  options = options || {};
-  cordova.exec(successCallback, failureCallback, 'AdMobAds', 'createBannerView', [options]);
+	if (typeof options === 'function') {
+		failureCallback = successCallback;
+		successCallback = options;
+		options = undefined;
+	}
+	options = options || {};
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'createBannerView', [options]);
 };
 
 /*
@@ -136,15 +138,15 @@ admob.createBannerView = function (options, successCallback, failureCallback) {
  * @param {function()} failureCallback The function to call if the ad failed to be shown.
  */
 admob.showBannerAd = function (show, successCallback, failureCallback) {
-  if (show === undefined) {
-    show = true;
+	if (show === undefined) {
+		show = true;
 
-  } else if (typeof show === 'function') {
-    failureCallback = successCallback;
-    successCallback = show;
-    show = true;
-  }
-  cordova.exec(successCallback, failureCallback, 'AdMobAds', 'showBannerAd', [show]);
+	} else if (typeof show === 'function') {
+		failureCallback = successCallback;
+		successCallback = show;
+		show = true;
+	}
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'showBannerAd', [show]);
 };
 
 /**
@@ -153,7 +155,7 @@ admob.showBannerAd = function (show, successCallback, failureCallback) {
  * @param {function()} failureCallback The function to call if failed to destroy view.
  */
 admob.destroyBannerView = function (successCallback, failureCallback) {
-  cordova.exec(successCallback, failureCallback, 'AdMobAds', 'destroyBannerView', []);
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'destroyBannerView', []);
 };
 
 /**
@@ -164,13 +166,13 @@ admob.destroyBannerView = function (successCallback, failureCallback) {
  * @param {function()} failureCallback The function to call if an ad failed to be requested.
  */
 admob.requestInterstitialAd = function (options, successCallback, failureCallback) {
-  if (typeof options === 'function') {
-    failureCallback = successCallback;
-    successCallback = options;
-    options = undefined;
-  }
-  options = options || {};
-  cordova.exec(successCallback, failureCallback, 'AdMobAds', 'requestInterstitialAd', [options]);
+	if (typeof options === 'function') {
+		failureCallback = successCallback;
+		successCallback = options;
+		options = undefined;
+	}
+	options = options || {};
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'requestInterstitialAd', [options]);
 };
 
 /**
@@ -180,7 +182,7 @@ admob.requestInterstitialAd = function (options, successCallback, failureCallbac
  * @param {function()} failureCallback The function to call if the ad failed to be shown.
  */
 admob.showInterstitialAd = function (successCallback, failureCallback) {
-  cordova.exec(successCallback, failureCallback, 'AdMobAds', 'showInterstitialAd', []);
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'showInterstitialAd', []);
 };
 
 /**
@@ -191,13 +193,13 @@ admob.showInterstitialAd = function (successCallback, failureCallback) {
  * @param {function()} failureCallback The function to call if an ad failed to be requested.
  */
 admob.requestRewardedAd = function (options, successCallback, failureCallback) {
-  if (typeof options === 'function') {
-    failureCallback = successCallback;
-    successCallback = options;
-    options = undefined;
-  }
-  options = options || {};
-  cordova.exec(successCallback, failureCallback, 'AdMobAds', 'requestRewardedAd', [options]);
+	if (typeof options === 'function') {
+		failureCallback = successCallback;
+		successCallback = options;
+		options = undefined;
+	}
+	options = options || {};
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'requestRewardedAd', [options]);
 };
 
 /**
@@ -207,9 +209,24 @@ admob.requestRewardedAd = function (options, successCallback, failureCallback) {
  * @param {function()} failureCallback The function to call if the ad failed to be shown.
  */
 admob.showRewardedAd = function (successCallback, failureCallback) {
-  cordova.exec(successCallback, failureCallback, 'AdMobAds', 'showRewardedAd', []);
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'showRewardedAd', []);
 };
 
+
+admob.requestAppOpenAd = function (options, successCallback, failureCallback) {
+	if (typeof options === 'function') {
+		failureCallback = successCallback;
+		successCallback = options;
+		options = undefined;
+	}
+
+	options = options || {};
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'requestAppOpenAd', [options]);
+};
+
+admob.showAppOpenAd = function (successCallback, failureCallback) {
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'showAppOpenAd', [])
+};
 
 
 /**
@@ -222,12 +239,12 @@ admob.showRewardedAd = function (successCallback, failureCallback) {
  * @param {function()} failureCallback The function to call if the ad failed to be shown.
  */
 admob.recordResolution = function (purchaseId, resolution, successCallback, failureCallback) {
-  if (purchaseId === undefined || resolution === undefined) {
-    if (typeof failureCallback === 'function') {
-      failureCallback('purchaseId and resolution should be specified.');
-    }
-  }
-  cordova.exec(successCallback, failureCallback, 'AdMobAds', 'recordResolution', [purchaseId, resolution]);
+	if (purchaseId === undefined || resolution === undefined) {
+		if (typeof failureCallback === 'function') {
+			failureCallback('purchaseId and resolution should be specified.');
+		}
+	}
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'recordResolution', [purchaseId, resolution]);
 };
 
 /**
@@ -240,17 +257,17 @@ admob.recordResolution = function (purchaseId, resolution, successCallback, fail
  * @param {function()} failureCallback      The function to call if the ad failed to be shown.
  */
 admob.recordPlayBillingResolution = function (purchaseId, billingResponseCode, successCallback, failureCallback) {
-  if (purchaseId === undefined || billingResponseCode === undefined) {
-    if (typeof failureCallback === 'function') {
-      failureCallback('purchaseId and billingResponseCode should be specified.');
-    }
-  }
-  cordova.exec(successCallback, failureCallback, 'AdMobAds', 'recordResolution', [purchaseId, billingResponseCode]);
+	if (purchaseId === undefined || billingResponseCode === undefined) {
+		if (typeof failureCallback === 'function') {
+			failureCallback('purchaseId and billingResponseCode should be specified.');
+		}
+	}
+	cordova.exec(successCallback, failureCallback, 'AdMobAds', 'recordResolution', [purchaseId, billingResponseCode]);
 };
 
 if (typeof module !== 'undefined') {
-  // Export admob
-  module.exports = admob;
+	// Export admob
+	module.exports = admob;
 }
 
 window.admob = admob;


### PR DESCRIPTION
This PR does the following:

* Adds support for "App Open" ads. The API is `admob.requestAppOpenAd({appOpenAdId: ''})` and `admob.showAppOpenAd()`
  * All events work correctly on Android. iOS emits `onAdLoaded` only. If necessary, I can do the rest. I just hate coding in Xcode and Obj-C.
* Adds a new variable for the iOS Admob id. The documentation has been updated to reflect it
* Fixes a bug with banner ads on iOS, so they actually work now
